### PR TITLE
Support multiple stat lists per spec

### DIFF
--- a/dataobj.lua
+++ b/dataobj.lua
@@ -14,7 +14,12 @@ function ns.ACTIVE_TALENT_GROUP_CHANGED()
 	local specIndex = GetSpecialization()
 	if specIndex then
 		local specID = GetSpecializationInfo(specIndex)
-		ns.dataobj.text = ns.priorities[specID][1]
+		local priorities = ns.priorities[specID]
+		local stat = priorities[1]
+		if type(stat) == "table" then
+			stat = stat[1]
+		end
+		ns.dataobj.text = stat
 	else
 		ns.dataobj.text = "???"
 	end

--- a/priorities.lua
+++ b/priorities.lua
@@ -113,8 +113,29 @@ local prios = {
 	-- [72] = "WARRIOR_FURY",
 	-- [73] = "WARRIOR_PROT",
 
-	-- [577] = "DH_HAVOC",
-	-- [581] = "DH_VENGEANCE",
+	-- Demon Hunter
+	[577] = { -- Havoc
+		STAT_CRITICAL_STRIKE,
+		STAT_VERSATILITY,
+		STAT_HASTE,
+		STAT_MASTERY
+	},
+	[581] = { -- Vengeance
+		{
+			title="Survivability",
+			STAT_VERSATILITY,
+			STAT_HASTE,
+			STAT_MASTERY,
+			STAT_CRITICAL_STRIKE
+		},
+		{
+			title="Damage Output",
+			STAT_MASTERY,
+			STAT_CRITICAL_STRIKE,
+			STAT_VERSATILITY,
+			STAT_HASTE
+		}
+	}
 }
 
 

--- a/tooltip.lua
+++ b/tooltip.lua
@@ -1,6 +1,17 @@
 
 local myname, ns = ...
 
+local function addStatsToTooltip(tip, spec, stats)
+	local title = stats.title
+	if title then
+		tip:AddLine(spec.." ("..title..")")
+	else
+		tip:AddLine(spec)
+	end
+	for _,stat in ipairs(stats) do
+		tip:AddLine(stat, 1,1,1)
+	end
+end
 
 function ns.dataobj.OnTooltipShow(tip)
 	tip:AddLine("picoPriorities")
@@ -9,10 +20,15 @@ function ns.dataobj.OnTooltipShow(tip)
 	if num then
 		for i=1,num do
 			local specID, spec = GetSpecializationInfo(i)
-			tip:AddLine(" ")
-			tip:AddLine(spec)
-			for j,stat in pairs(ns.priorities[specID]) do
-				tip:AddLine(stat, 1,1,1)
+			local priorities = ns.priorities[specID]
+			if type(priorities[1]) ~= "table" then
+				tip:AddLine(" ")
+				addStatsToTooltip(tip, spec, priorities)
+			else
+				for _,stats in ipairs(priorities) do
+					tip:AddLine(" ")
+					addStatsToTooltip(tip, spec, stats)
+				end
 			end
 		end
 	else


### PR DESCRIPTION
This is so tank specs can list separate specs for survivability and damage output.

Right now the LDB text will always just use the first stat from the first stat list. It would be nice to support picking a stat type (and then showing just that type in the tooltip), but that requires saved data and some way to pick (e.g. a right-click menu), which is more complicated.

Add Demon Hunter stats.
